### PR TITLE
Create 400 Bad Request

### DIFF
--- a/400 Bad Request
+++ b/400 Bad Request
@@ -1,0 +1,5 @@
+400 Bad Request
+
+The HTTP 400 Bad Request client error response status code indicates that the server would not process the request due to something the server considered to be a client error. The reason for a 400 response is typically due to malformed request syntax, invalid request message framing, or deceptive request routing.
+
+Clients that receive a 400 response should expect that repeating the request without modification will fail with the same error.


### PR DESCRIPTION
400 Bad Request

The HTTP 400 Bad Request client error response status code indicates that the server would not process the request due to something the server considered to be a client error. The reason for a 400 response is typically due to malformed request syntax, invalid request message framing, or deceptive request routing.

Clients that receive a 400 response should expect that repeating the request without modification will fail with the same error.