### PR TITLE
feat: Add more repos to contrib report

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
-          REPOSITORY: "mdn/content,mdn/yari,mdn/rari,mdn/translated-content"
+          REPOSITORY: "mdn/content,mdn/yari,mdn/rari,mdn/translated-content,mdn/browser-compat-data"
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
 

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -32,7 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
-          REPOSITORY: "mdn/content"
+          REPOSITORY: "mdn/content,mdn/yari,mdn/rari,mdn/translated-content"
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
 


### PR DESCRIPTION
Adding 'mdn/yari', 'mdn/rari', and 'mdn/translated-content'

Tested in a private repo, and the workflow run completes in 17min 30s.

I can try in future for all MDN repos, but I suspect this will be extremely slow due to API usage.