### PR TITLE
ci(CODEOWNERS): add content team for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,5 @@
 * @mdn/community
 
 /.github/workflows/ @mdn/engineering
-/.github/CODEOWNERS @mdn/engineering
+/.github/CODEOWNERS @mdn/content-team @mdn/engineering
 /SECURITY.md @mdn/engineering


### PR DESCRIPTION
### Description

To align with the rest of the org.
